### PR TITLE
feat: ability to pass in custom container styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,20 +37,20 @@ React native reanimated confetti, a simple yet fully customizable component made
   ```
 
 ### Props
-
 | Name               | Type                   | Description                                 | Required | Default         |
-|--------------------|------------------------|---------------------------------------------|----------|-----------------|
+| ------------------ | ---------------------- | ------------------------------------------- | -------- | --------------- |
 | count              | number                 | items count to display                      |          | 100             |
 | origin             | {x: number, y: number} | animation position origin                   |          | { x: -10, y: 0} |
 | explosionSpeed     | number                 | explosion duration (ms) from origin to top  |          | 350             |
 | fallSpeed          | number                 | fall duration (ms) from top to bottom       |          | 3000            |
 | fadeOut            | boolean                | make the confettis disappear at the end     |          | false           |
-| colors             | string[]               | give your own colors to the confettis       |          | default colors  |
+| colors             | string\[]              | give your own colors to the confettis       |          | default colors  |
 | onlyShowCustomSvgs | boolean                | only showing custom svgs based on svgs prop |          | false           |
-| svgs               | React.JSX.Element[]    | array containing your custom svgs           |          | []              |
+| svgs               | React.JSX.Element\[]   | array containing your custom svgs           |          | \[]             |
 | delay              | number                 | cannon / animation delay                    |          | 0               |
 | minSize            | number                 | min size of confetti shapes                 |          | 20              |
 | maxSize            | number                 | max size of confetti shapes                 |          | 30              |
+| style              | ViewStyle \| object    | container styles                            |          | {}              |
 
 ### Hotdog confetti example
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "homepage": "https://marcuzgabriel.github.io/react-native-reanimated-confetti/",
-  "name": "@rnrc/monorepo",
+  "name": "react-native-reanimated-confetti",
   "author": "Marcuz Gabriel Larsen <marcuzgabriel@gmail.com>",
   "version": "1.1.0",
   "license": "MIT",

--- a/packages/npm/src/Confetti.tsx
+++ b/packages/npm/src/Confetti.tsx
@@ -22,6 +22,7 @@ export { ConfettiProps };
  * @maxSize maximum size of the confetti
  * @colors array of colors
  * @delay delay of the animation
+ * @style container styles
  */
 const Confetti: React.FC<ConfettiProps> = ({
   svgs = DEFAULT_CONFIG.SVGS,
@@ -35,6 +36,7 @@ const Confetti: React.FC<ConfettiProps> = ({
   maxSize = DEFAULT_CONFIG.MAX_SIZE,
   colors = DEFAULT_CONFIG.COLORS,
   delay = DEFAULT_CONFIG.DELAY,
+  style = DEFAULT_CONFIG.CONTAINER_STYLE,
 }) => {
   const [particles, setParticles] = useState<IParticle[]>([]);
   const createParticle = useCreateParticle();
@@ -46,7 +48,7 @@ const Confetti: React.FC<ConfettiProps> = ({
   }, [createParticle, count, particles]);
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, style]}>
       {particles.map((data, index) => (
         <Particle
           key={index}
@@ -69,9 +71,11 @@ const Confetti: React.FC<ConfettiProps> = ({
 
 const styles = StyleSheet.create({
   container: {
-    ...StyleSheet.absoluteFillObject,
-    overflow: 'hidden',
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
   },
-});
+})
 
 export default memo(Confetti);

--- a/packages/npm/src/contants/index.ts
+++ b/packages/npm/src/contants/index.ts
@@ -10,4 +10,5 @@ export const DEFAULT_CONFIG = {
   DELAY: 0,
   COLORS: ['#48b0f1', '#8fed8f', '#75f3c8', '#fff045', '#f357ac', '#b285fb'],
   SVGS: [],
+  CONTAINER_STYLE: {}
 };

--- a/packages/npm/src/types/index.ts
+++ b/packages/npm/src/types/index.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { ViewStyle } from 'react-native';
 
 export type IShape = {
   height: number;
@@ -39,4 +40,5 @@ export type ConfettiProps = {
   fallSpeed?: number;
   fadeOut?: boolean;
   onlyShowCustomSvgs?: boolean;
+  style?: ViewStyle | object;
 };


### PR DESCRIPTION
Thanks for your great work! We've been using an old library for confetti and it has caused some problems because it runs on the JS thread, but yours is super smooth.

Two small changes:

1. `Confetti` component can now take a `style` prop, allowing passing in custom styles to the container.
3. Removed `overflow: hidden`  and `top: 0` from the default container style to be less opinionated and avoid clashes with custom styles.
